### PR TITLE
Prevent bug in computePlaneDistance from destroying frustum calculation.

### DIFF
--- a/Source/Scene/View.js
+++ b/Source/Scene/View.js
@@ -275,8 +275,8 @@ define([
                     }
 
                     distances = boundingVolume.computePlaneDistances(position, direction, distances);
-                    near = Math.min(near, distances.start);
-                    far = Math.max(far, distances.stop);
+                    near = isNaN(distances.start) ? near : Math.min(near, distances.start);
+                    far = isNaN(distances.start) ? far : Math.max(far, distances.stop);
 
                     // Compute a tight near and far plane for commands that receive shadows. This helps compute
                     // good splits for cascaded shadow maps. Ignore commands that exceed the maximum distance.


### PR DESCRIPTION
We ran into a strange edge-case where some incomplete data would end up in a broken frustum calculation which caused Cesium to crash out.

I traced it to a NaN entering the near and far values here.